### PR TITLE
config: move alias prop initialization to an action

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -35,6 +35,7 @@ event_templates("nethserver-ntopng-update", qw(
 ));
 event_actions("nethserver-ntopng-update", qw(
     initialize-default-databases 00
+    nethserver-ntopng-conf 02
 ));
 event_services("nethserver-ntopng-update", qw(
     ntopng restart

--- a/root/etc/e-smith/events/actions/nethserver-ntopng-conf
+++ b/root/etc/e-smith/events/actions/nethserver-ntopng-conf
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+use esmith::ConfigDB;
+use esmith::util;
+my $confdb = esmith::ConfigDB->open;
+my $ntopng = $confdb->get('ntopng') or die "No ntopng db entry found\n";
+my $alias = $ntopng->prop('alias') || "";
+
+# initialize alias if needed
+if ($alias eq "") {
+    $alias = esmith::util::genRandomHash();
+    $confdb->set_prop('ntopng','alias',$alias);
+}

--- a/root/etc/e-smith/templates/etc/httpd/admin-conf.d/ntopng.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/admin-conf.d/ntopng.conf/10base
@@ -3,14 +3,8 @@
     use esmith::util;
     my $confdb = esmith::ConfigDB->open;
     my $ntopng = $confdb->get('ntopng') or die "No ntopng db entry found\n";
-    my $alias = $ntopng->prop('alias') || "";
+    my $alias = $ntopng->prop('alias') or die "Ntopng alias not initialized!";
     my $port = $ntopng->prop('TCPPort') || "3000";
-
-    # initialize alias if needed
-    if ($alias eq "") {
-        $alias = esmith::util::genRandomHash();
-        $confdb->set_prop('ntopng','alias',$alias);
-    }
 
     $OUT .= "ProxyPass /$alias http://localhost:$port\n";
     $OUT .= "ProxyPassReverse /$alias http://localhost:$port\n";


### PR DESCRIPTION
Avoid race condition: if ntopng.conf template is expanded
before httpd.conf, alias prop is not initialized.
As a consequence, ntopng is not accessible using a proxy pass.

This fix a possible upgrade problem from NS 7.3 where ntopng was installed from NethForge.