### PR TITLE
conf: better handling of view option

### DIFF
--- a/root/etc/e-smith/templates/etc/ntopng/ntopng.conf/10base
+++ b/root/etc/e-smith/templates/etc/ntopng/ntopng.conf/10base
@@ -22,7 +22,9 @@
         }
     }
 
-    $OUT.="-i view: $ntopng{'Interfaces'}\n";
+    if (scalar(@interfaces) > 1) {
+        $OUT.="-i view: $ntopng{'Interfaces'}\n";
+    }
     $OUT.="-w=$port\n";
     $OUT.="-m=".join(',',@nets)."\n";
     if ($auth eq 'disabled') { 


### PR DESCRIPTION
Do not enable view option if there is only one network selected interface,
since ntopng doesn't behave well with views containing only one
interface.