### PR TITLE
HACK: fix restart on upgrade

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -36,6 +36,7 @@ event_templates("nethserver-ntopng-update", qw(
 event_actions("nethserver-ntopng-update", qw(
     initialize-default-databases 00
     nethserver-ntopng-conf 02
+    nethserver-ntopng-check 98
 ));
 event_services("nethserver-ntopng-update", qw(
     ntopng restart

--- a/root/etc/e-smith/events/actions/nethserver-ntopng-check
+++ b/root/etc/e-smith/events/actions/nethserver-ntopng-check
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#
+# Restart ntopng if HTTP port is not reacheable
+# NethServer/dev#5403
+#
+
+port=`/sbin/e-smith/config getprop ntopng TCPPort`
+i=0
+MAX=5
+
+while [ $i -lt 5 ]; do
+    if curl -s http://localhost:$port 2>/dev/null; then
+        exit 0
+    else
+        sleep 1
+        let i+=1
+    fi
+done
+
+systemctl restart ntopng


### PR DESCRIPTION
After upgrading from 3.2 to 3.3,
ntopng starts but doesn't listen on HTTP port.
A restart fix this behavior.

Nethserver/dev#5403