### PR TITLE
Ntopng cleanup

### DIFF
--- a/root/etc/cron.daily/ntopng-cleanup
+++ b/root/etc/cron.daily/ntopng-cleanup
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Delete files not updated in the last 30 days
-[ -d /var/tmp/ntopng/ ] && /usr/bin/find /var/tmp/ntopng/* -mindepth 1 -type f -mtime +30 -delete > /dev/null
+[ -d /var/tmp/ntopng/ ] && /usr/bin/find /var/tmp/ntopng/* -mindepth 1 -type f -mtime +30 -delete &> /dev/null

--- a/root/etc/cron.weekly/ntopng-cleanup
+++ b/root/etc/cron.weekly/ntopng-cleanup
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# top_talkers.db grows too much, just clean it once in a while
+
+/usr/bin/find /var/tmp/ntopng/ -name top_talkers.db -delete
+/usr/bin/systemctl restart ntopng


### PR DESCRIPTION
- Avoid cron job errors when deleting files
- Avoid filling up the disk with top_talkers database

NethServer/dev#6158