### PR TITLE
Restored link in Cockpit Applications page

### DIFF
--- a/api/read
+++ b/api/read
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+input=$(cat)
+action=$(jq -r .action <<<"$input")
+protocol=$(jq -r .location.protocol <<<"$input")
+host=$(jq -r .location.hostname <<<"$input")
+
+if [[ $action == "app-info" ]]; then
+    alias=$(/sbin/e-smith/config getprop ntopng alias)
+    printf '{"url":"%s"}' "${protocol}//${host}:980/${alias}"
+fi

--- a/nethserver-ntopng.json
+++ b/nethserver-ntopng.json
@@ -19,5 +19,8 @@
     "url": "https://github.com/NethServer/nethserver-ntopng",
     "email": "edoardo.spadoni@nethesis.it, andrea.leardini@nethesis.it"
   },
+  "infoapi": {
+    "path": "nethserver-ntopng/read"
+  },
   "icon": "logo.png"
 }

--- a/root/etc/sudoers.d/50_nsapi_nethserver_ntopng
+++ b/root/etc/sudoers.d/50_nsapi_nethserver_ntopng
@@ -2,6 +2,7 @@
 # nsapi_nethserver_ntopng
 #
 Cmnd_Alias NSAPI_NETHSERVER_NTOPNG = \
+    /usr/libexec/nethserver/api/nethserver-ntopng/read, \
     /usr/libexec/nethserver/api/nethserver-ntopng/dashboard/read, \
     /usr/libexec/nethserver/api/nethserver-ntopng/settings/read, \
     /usr/libexec/nethserver/api/nethserver-ntopng/settings/update, \


### PR DESCRIPTION
Restored link to open **ntopng** web interface from Cockpit **Applications** page

NethServer/dev#6199