### PR TITLE
api: fix traffic-by-protocol chart

### DIFF
--- a/api/dashboard/read
+++ b/api/dashboard/read
@@ -80,6 +80,9 @@ def get_traffic_by_protocol():
 
     for elem in output_json:
         protocol = elem['proto']
+        # skip bad elements
+        if not 'throughput_bps' in elem:
+            continue
         # convert from bytes per second to bits per second
         throughput = elem['throughput_bps'] * 8
 


### PR DESCRIPTION
Sometimes ntopng returns invalid data.
This is a workaround to avoid an empty traffic-by-protocol chart